### PR TITLE
Add commands for installing and browsing Elm packages

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,6 @@
 	"editor.insertSpaces": false,
 	"tslint.enable": true,
 	"typescript.tsc.autoDetect": "off",
-	"typescript.preferences.quoteStyle": "single"
+	"typescript.preferences.quoteStyle": "single",
+	"editor.tabSize": 2
 }

--- a/client/src/elmPackage.ts
+++ b/client/src/elmPackage.ts
@@ -1,0 +1,147 @@
+import * as vscode from 'vscode';
+import * as utils from './utils'
+
+const request = require('request');
+let packageTerminal: vscode.Terminal;
+
+interface ElmPackageQuickPickItem extends vscode.QuickPickItem {
+	info: any;
+}
+
+function transformToPackageQuickPickItems(
+	packages: any[],
+): ElmPackageQuickPickItem[] {
+	return Object.keys(packages).map((item: any) => {
+		return { label: item, description: item, info: packages[item] };
+	});
+}
+
+function transformToPackageVersionQuickPickItems(
+	selectedPackage: ElmPackageQuickPickItem,
+): vscode.QuickPickItem[] {
+	return selectedPackage.info.map((version: any) => {
+		return { label: version, description: null };
+	});
+}
+
+function transformToQuickPickItems(packages: any[]): vscode.QuickPickItem[] {
+	return Object.keys(packages).map((item: any) => {
+		return { label: item, description: '', info: packages[item] };
+	});
+}
+
+function getJSON(): Thenable<any[]> {
+	return new Promise((resolve, reject) => {
+		request('https://package.elm-lang.org/all-packages', (err: any, _: any, body: any) => {
+			if (err) {
+				reject(err);
+			} else {
+				let json;
+				try {
+					json = JSON.parse(body);
+				} catch (e) {
+					reject(e);
+				}
+				resolve(json);
+			}
+		});
+	});
+}
+
+function getInstallPackageCommand(packageToInstall: string): string {
+	const config: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration(
+		'ElmLS',
+	);
+	let t: string = <string>config.get('elmLS.elmPath');
+	t = t == undefined ? "elm" : t
+
+	return t + ' install ' + packageToInstall;
+}
+
+function installPackageInTerminal(packageToInstall: string) {
+	try {
+		let installPackageCommand = getInstallPackageCommand(packageToInstall);
+		if (packageTerminal !== undefined) {
+			packageTerminal.dispose();
+		}
+		packageTerminal = vscode.window.createTerminal('Elm Package Install');
+		let [
+			installPackageLaunchCommand,
+			clearCommand,
+		] = utils.getTerminalLaunchCommands(installPackageCommand);
+		packageTerminal.sendText(clearCommand, true);
+		packageTerminal.sendText(installPackageLaunchCommand, true);
+		packageTerminal.show(false);
+	} catch (error) {
+		vscode.window.showErrorMessage(
+			'Cannot start Elm Package install. ' + error,
+		);
+	}
+}
+
+function browsePackage(): Thenable<void> {
+	const quickPickPackageOptions: vscode.QuickPickOptions = {
+		matchOnDescription: true,
+		placeHolder: 'Choose a package',
+	};
+	const quickPickVersionOptions: vscode.QuickPickOptions = {
+		matchOnDescription: false,
+		placeHolder: 'Choose a version, or press <esc> to browse the latest',
+	};
+
+	return getJSON()
+		.then(transformToPackageQuickPickItems)
+		.then(packages =>
+			vscode.window.showQuickPick(packages, quickPickPackageOptions),
+		)
+		.then(selectedPackage => {
+			if (selectedPackage === undefined) {
+				return; // no package
+			}
+			return vscode.window
+				.showQuickPick(
+					transformToPackageVersionQuickPickItems(selectedPackage),
+					quickPickVersionOptions,
+				)
+				.then(selectedVersion => {
+					let uri = selectedVersion
+						? vscode.Uri.parse(
+							'https://package.elm-lang.org/packages/' +
+							selectedPackage.label +
+							'/' +
+							selectedVersion.label,
+						)
+						: vscode.Uri.parse(
+							'https://package.elm-lang.org/packages/' +
+							selectedPackage.label +
+							'/latest',
+						);
+					vscode.commands.executeCommand('vscode.open', uri);
+				})
+				.then(() => { });
+		});
+}
+
+function runInstall(): Thenable<void> {
+	const quickPickOptions: vscode.QuickPickOptions = {
+		matchOnDescription: true,
+		placeHolder:
+			'Choose a package, or press <esc> to install all packages in elm-package.json',
+	};
+
+	return getJSON()
+		.then(transformToQuickPickItems)
+		.then(items => vscode.window.showQuickPick(items, quickPickOptions))
+		.then(value => {
+			const packageName = value ? value.label : '';
+			return installPackageInTerminal(packageName);
+		});
+}
+
+
+export function activatePackage(): vscode.Disposable[] {
+	return [
+		vscode.commands.registerCommand('elm.install', runInstall),
+		vscode.commands.registerCommand('elm.browsePackage', browsePackage),
+	];
+}

--- a/client/src/elmPackage.ts
+++ b/client/src/elmPackage.ts
@@ -126,13 +126,16 @@ function runInstall(): Thenable<void> {
 	const quickPickOptions: vscode.QuickPickOptions = {
 		matchOnDescription: true,
 		placeHolder:
-			'Choose a package, or press <esc> to install all packages in elm-package.json',
+			'Choose a package, or press <esc> to cancel',
 	};
 
 	return getJSON()
 		.then(transformToQuickPickItems)
 		.then(items => vscode.window.showQuickPick(items, quickPickOptions))
 		.then(value => {
+			if (value === undefined) {
+				return; // no package
+			}
 			const packageName = value ? value.label : '';
 			return installPackageInTerminal(packageName);
 		});

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -50,6 +50,8 @@ export async function activate(context: ExtensionContext) {
     const elmJsonFolder = getElmJsonFolder(uri);
     stopClient(elmJsonFolder);
   });
+  let packageDisposables = Package.activatePackage()
+  packageDisposables.forEach(d => context.subscriptions.push(d))
 }
 
 function findTopLevelFolders(listOfElmJsonFolders: Uri[]) {
@@ -166,7 +168,6 @@ function startClient(context: ExtensionContext, elmWorkspace: Uri) {
 
   // Start the client. This will also launch the server
   languageClient.start();
-  Package.activatePackage()
   clients.set(elmWorkspace.fsPath, languageClient);
 }
 

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -17,6 +17,8 @@ import {
   RevealOutputChannelOn,
 } from "vscode-languageclient";
 
+import * as Package from "./elmPackage";
+
 let languageClient: LanguageClient;
 const elmJsonGlob = "**/elm.json";
 
@@ -164,6 +166,7 @@ function startClient(context: ExtensionContext, elmWorkspace: Uri) {
 
   // Start the client. This will also launch the server
   languageClient.start();
+  Package.activatePackage()
   clients.set(elmWorkspace.fsPath, languageClient);
 }
 

--- a/client/src/utils.ts
+++ b/client/src/utils.ts
@@ -1,0 +1,27 @@
+import * as vscode from 'vscode';
+
+export const isWindows = process.platform === 'win32';
+
+function isPowershell() {
+  try {
+    const config: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration(
+      'ElmLS',
+    );
+    const t: string = <string>config.get('terminal.integrated.shell.windows');
+    return t.toLowerCase().includes('powershell');
+  } catch (error) {
+    return false;
+  }
+}
+
+export function getTerminalLaunchCommands(command: string): [string, string] {
+  if (isWindows) {
+    if (isPowershell()) {
+      return [`cmd /c ${command}`, 'clear'];
+    } else {
+      return [`${command}`, 'cls'];
+    }
+  } else {
+    return [command, 'clear'];
+  }
+}

--- a/client/src/utils.ts
+++ b/client/src/utils.ts
@@ -4,9 +4,7 @@ export const isWindows = process.platform === 'win32';
 
 function isPowershell() {
   try {
-    const config: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration(
-      'ElmLS',
-    );
+    const config: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration();
     const t: string = <string>config.get('terminal.integrated.shell.windows');
     return t.toLowerCase().includes('powershell');
   } catch (error) {

--- a/package.json
+++ b/package.json
@@ -67,6 +67,18 @@
         "path": "./syntaxes/elm.json"
       }
     ],
+    "commands":[
+      {
+        "command": "elm.install",
+        "title": "Install Package",
+        "category": "Elm"
+      },
+      {
+        "command": "elm.browsePackage",
+        "title": "Browse Package",
+        "category": "Elm"
+      }
+    ],
     "configuration": {
       "type": "object",
       "title": "ElmLS",


### PR DESCRIPTION
This adds 2 commands:
* Elm: Install package - users is prompted with the list of elm packages, select package. We then run `elm install <PACKAGE>` command in terminal window (user will need to confirm changes to the dependencies graph in the terminal, just like during normal installation from command line)
* Elm: Browse package -  users is prompted with the list of elm packages, select package, select version. We open browser window with documentation from given package.
![2019-08-05 18 58 17](https://user-images.githubusercontent.com/5427083/62481850-e32e4480-b7b3-11e9-82e4-f5c5fc49a52a.gif)
