### PR TITLE
Merge pull request #69 from sentience/fix-ts-errors

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "target": "es6",
     "outDir": "out",
     "strict": true,
-    "lib": ["es6"],
+    "lib": ["es6", "ES2019"],
     "sourceMap": true,
     "esModuleInterop": true
   },


### PR DESCRIPTION
When building the Elm Language Server submodule from this project in development, I was getting errors relating to `Array.flatMap` not being available in the configured version of TypeScript. Adding ES2019, which includes these new `Array` features, resolved the issue for me.