### PR TITLE
Fix issues launching VS Code extension host

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,12 +7,7 @@
       "request": "launch",
       "name": "Launch Client",
       "runtimeExecutable": "${execPath}",
-      "args": [
-        // Needs to be set to your vscode path, for arch this works
-        "/usr/lib/code",
-        "--extensionDevelopmentPath=${workspaceRoot}",
-        "code --inspect-extensions=9993"
-      ],
+      "args": ["--extensionDevelopmentPath=${workspaceRoot}"],
       "sourceMaps": true,
       "outFiles": ["${workspaceRoot}/client/out/**/*.js"],
       "preLaunchTask": {


### PR DESCRIPTION
The `args` provided for VS Code in the “Launch Client” launch configuration were telling the editor to attempt to open a file named "/usr/lib/code", and another named "code --inspect-extensions=9993", neither of which was intended. With this change, the editor now launches as expected with the previously-open project/files restored.