### PR TITLE
Cache codelens requests to prevent duplicate server requests

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -21,6 +21,7 @@ import {
   ResolveCodeLensSignature,
   RevealOutputChannelOn,
   TransportKind,
+  ProvideCodeLensesSignature,
 } from "vscode-languageclient";
 import * as Package from "./elmPackage";
 import * as RefactorAction from "./refactorAction";
@@ -186,8 +187,41 @@ export function deactivate(): Thenable<void> | undefined {
   }
   return Promise.all(promises).then(() => undefined);
 }
+class CachedCodeLensResponse {
+  response?: ProviderResult<CodeLens[]>;
+  version: number = -1;
+  document: string = "";
+
+  matches(document: TextDocument): boolean {
+    return (
+      this.version === document.version &&
+      this.document === document.uri.toString()
+    );
+  }
+
+  update(document: TextDocument, response: ProviderResult<CodeLens[]>) {
+    this.response = response;
+    this.version = document.version;
+    this.document = document.uri.toString();
+  }
+}
+
+const cachedCodeLens = new CachedCodeLensResponse();
 
 export class CodeLensResolver implements Middleware {
+  public provideCodeLenses(
+    this: void,
+    document: TextDocument,
+    token: CancellationToken,
+    next: ProvideCodeLensesSignature,
+  ): ProviderResult<CodeLens[]> {
+    if (!cachedCodeLens.matches(document)) {
+      cachedCodeLens.update(document, next(document, token));
+    }
+
+    return cachedCodeLens.response;
+  }
+
   public resolveCodeLens(
     codeLens: CodeLens,
     token: CancellationToken,


### PR DESCRIPTION
Because other extensions (like `Live Share`) can request codelens (and other things) on a document, it results in multiple duplicate server requests for the same document version. I was running into an issue where it was sending up to 4 server requests for a single document change. This is partly due a [live share bug](https://github.com/MicrosoftDocs/live-share/issues/3116) that it was happening when no live share session was running. But even so, I think we should still cache any duplicate requests. I wasn't thrilled with the solution since I couldn't use a class property, but I think the global const should still work good. 