### PR TITLE
connection to LSP with findTests request and various improvements

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,3 @@
 [submodule "server"]
 	path = server
-	url = git@github.com:frawa/elm-language-server.git
-	branch = find-tests
+	url = https://github.com/elm-tooling/elm-language-server.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "server"]
 	path = server
-	url = https://github.com/elm-tooling/elm-language-server.git
+	url = git@github.com:frawa/elm-language-server.git
+	branch = find-tests

--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -20,7 +20,6 @@ module.exports = {
     project: ["./tsconfig.json"],
   },
   plugins: ["@typescript-eslint", "prettier"],
-  ignorePatterns: ["*.test.ts"],
   rules: {
     "prettier/prettier": "error",
     "@typescript-eslint/no-unsafe-member-access": "warn",

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -236,6 +236,10 @@ export function activate(context: ExtensionContext): void {
     };
   };
 
+  const getClient: (folder: WorkspaceFolder) => LanguageClient | undefined = (
+    folder,
+  ) => clients.get(folder.uri.toString());
+
   void Workspace.findFiles(
     "**/elm.json",
     "**/{node_modules,elm-stuff}/**",
@@ -243,7 +247,12 @@ export function activate(context: ExtensionContext): void {
     elmJsons.forEach((elmJsonPath) => {
       const elmRootFolder = Uri.parse(path.dirname(elmJsonPath.fsPath));
       if (fs.existsSync(path.join(elmRootFolder.fsPath, "tests"))) {
-        TestRunner.activate(context, elmRootFolder, configuredElmBinaries);
+        TestRunner.activate(
+          context,
+          elmRootFolder,
+          configuredElmBinaries,
+          getClient,
+        );
       }
     });
   });

--- a/client/src/protocol.ts
+++ b/client/src/protocol.ts
@@ -46,7 +46,7 @@ export const FindTestsRequest = new RequestType<
 >("elm/findTests");
 
 export interface IFindTestsParams {
-  workspaceRoot: URI;
+  projectFolder: URI;
 }
 
 export interface IFindTestsResponse {

--- a/client/src/protocol.ts
+++ b/client/src/protocol.ts
@@ -1,4 +1,4 @@
-import { CodeActionParams, RequestType } from "vscode-languageclient";
+import { CodeActionParams, RequestType, URI } from "vscode-languageclient";
 
 export const GetMoveDestinationRequest = new RequestType<
   IMoveParams,
@@ -38,3 +38,24 @@ export const UnexposeRequest = new RequestType<
   void,
   void
 >("elm/unexpose");
+
+export const FindTestsRequest = new RequestType<
+  IFindTestsParams,
+  IFindTestsResponse,
+  void
+>("elm/findTests");
+
+export interface IFindTestsParams {
+  workspaceRoot: URI;
+}
+
+export interface IFindTestsResponse {
+  suites?: TestSuite[];
+}
+
+export type TestSuite = {
+  label: string | string[];
+  tests?: TestSuite[];
+  file: string;
+  position: { line: number; character: number };
+};

--- a/client/src/protocol.ts
+++ b/client/src/protocol.ts
@@ -54,7 +54,7 @@ export interface IFindTestsResponse {
 }
 
 export type TestSuite = {
-  label: string | string[];
+  label: string;
   tests?: TestSuite[];
   file: string;
   position: { line: number; character: number };

--- a/client/src/test-runner/adapter.ts
+++ b/client/src/test-runner/adapter.ts
@@ -260,7 +260,7 @@ function toTestSuiteInfo(
   prefixId: string,
 ): TestSuiteInfo | TestInfo | undefined {
   const id = toId(prefixId, suite);
-  const label = toLabel(suite);
+  const label = suite.label;
   if (!label || !id) {
     return undefined;
   }
@@ -284,15 +284,8 @@ function toTestSuiteInfo(
       };
 }
 
-function toLabel(suite: TestSuite): string {
-  return typeof suite.label === "string" ? suite.label : suite.label.join("..");
-}
-
 function toId(prefix: string, suite: TestSuite): string | undefined {
-  return typeof suite.label === "string"
-    ? `${prefix}/${suite.label}`
-    : // : `${prefix}/${suite.label.join("-")}`;
-      undefined;
+  return `${prefix}/${suite.label}`;
 }
 
 // TODO share?

--- a/client/src/test-runner/adapter.ts
+++ b/client/src/test-runner/adapter.ts
@@ -168,14 +168,14 @@ export class ElmTestAdapter implements TestAdapter {
       return;
     }
 
-    const [files, testIds] = getFilesAndAllTestIds(tests, this.loadedSuite);
+    const [uris, testIds] = getFilesAndAllTestIds(tests, this.loadedSuite);
     this.testStatesEmitter.fire(<TestRunStartedEvent>{
       type: "started",
       tests: testIds,
     });
 
     try {
-      const suiteOrError = await this.runner.runSomeTests(files);
+      const suiteOrError = await this.runner.runSomeTests(uris);
       if (typeof suiteOrError === "string") {
         console.log("Error running tests", suiteOrError);
         this.testsEmitter.fire(<TestLoadFinishedEvent>{

--- a/client/src/test-runner/adapter.ts
+++ b/client/src/test-runner/adapter.ts
@@ -21,7 +21,20 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
+import { Test } from "mocha";
+import { toUnicode } from "punycode";
 import * as vscode from "vscode";
+import { WorkspaceFolder } from "vscode";
+import {
+  ExecuteCommandParams,
+  ExecuteCommandRequest,
+  LanguageClient,
+  Position,
+  ReferenceParams,
+  ReferencesRequest,
+  WorkspaceSymbolParams,
+  WorkspaceSymbolRequest,
+} from "vscode-languageclient/node";
 import {
   TestAdapter,
   TestLoadStartedEvent,
@@ -32,11 +45,17 @@ import {
   TestEvent,
   RetireEvent,
   TestSuiteInfo,
+  TestInfo,
 } from "vscode-test-adapter-api";
 import { Log } from "vscode-test-adapter-util";
-import { setTestContent } from "../test/helper";
+import {
+  FindTestsRequest,
+  IFindTestsParams,
+  IFindTestsResponse,
+  TestSuite,
+} from "../protocol";
 import { ElmTestRunner } from "./runner";
-import { getTestsRoot, IElmBinaries, walk } from "./util";
+import { getFilesAndAllTestIds, getTestsRoot, IElmBinaries } from "./util";
 
 export class ElmTestAdapter implements TestAdapter {
   private disposables: { dispose(): void }[] = [];
@@ -63,6 +82,7 @@ export class ElmTestAdapter implements TestAdapter {
 
   private isLoading = false;
   private runner: ElmTestRunner;
+  private loadedSuite?: TestSuiteInfo;
   private watcher?: vscode.Disposable;
 
   constructor(
@@ -70,6 +90,9 @@ export class ElmTestAdapter implements TestAdapter {
     private readonly elmProjectFolder: vscode.Uri,
     private readonly log: Log,
     configuredElmBinaries: () => IElmBinaries,
+    private readonly getClient: (
+      folder: WorkspaceFolder,
+    ) => LanguageClient | undefined,
   ) {
     this.log.info("Initializing Elm Test Runner adapter");
 
@@ -86,54 +109,95 @@ export class ElmTestAdapter implements TestAdapter {
   }
 
   async load(): Promise<void> {
-    this.log.info("Loading tests");
-
     if (this.isLoading) {
       return;
     }
 
-    this.testsEmitter.fire(<TestLoadStartedEvent>{ type: "started" });
-    try {
+    this.log.info("Loading tests");
+
+    const client = this.getClient(this.workspace);
+    if (client) {
       this.isLoading = true;
-      const loadedEvent: TestLoadFinishedEvent = await this.runner.runAllTests();
-      this.testsEmitter.fire(loadedEvent);
-      void this.fire(loadedEvent);
-    } catch (error) {
-      this.log.info("Failed to load tests", error);
-      this.testsEmitter.fire(<TestLoadFinishedEvent>{
-        type: "finished",
-        errorMessage: String(error),
+      void client.onReady().then(async () => {
+        const input: IFindTestsParams = {
+          workspaceRoot: this.workspace.uri.toString(),
+        };
+        try {
+          const response = await client.sendRequest(FindTestsRequest, input);
+          const id = this.workspace.name;
+          const children =
+            response.suites?.map((s) => {
+              // TODO move into LSP
+              const modulePath = vscode.Uri.parse(s.file).fsPath.split("/");
+              const moduleFile = modulePath[modulePath.length - 1];
+              const module = moduleFile.substring(
+                0,
+                moduleFile.indexOf(".elm"),
+              );
+              return toTestSuiteInfo(s, id + "/" + module);
+            }) ?? [];
+          const suite: TestSuiteInfo = {
+            type: "suite",
+            label: id,
+            id,
+            children,
+          };
+          const loadedEvent: TestLoadFinishedEvent = {
+            type: "finished",
+            suite,
+          };
+          this.loadedSuite = suite;
+          this.testsEmitter.fire(loadedEvent);
+          this.log.info("Loaded tests");
+        } catch (error) {
+          console.log("Failed to load tests", error);
+          this.log.info("Failed to load tests", error);
+          this.testsEmitter.fire(<TestLoadFinishedEvent>{
+            type: "finished",
+            errorMessage: String(error),
+          });
+        } finally {
+          this.isLoading = false;
+        }
       });
-    } finally {
-      this.isLoading = false;
     }
   }
 
   async run(tests: string[]): Promise<void> {
     this.log.info("Running tests", tests);
 
-    const [files, testIds] = this.runner.getFilesAndAllTestIds(tests);
+    if (!this.loadedSuite) {
+      this.log.info("Not loaded", tests);
+      return;
+    }
+
+    console.log("FW loaded", this.loadedSuite);
+    const [files, testIds] = getFilesAndAllTestIds(tests, this.loadedSuite);
     this.testStatesEmitter.fire(<TestRunStartedEvent>{
       type: "started",
       tests: testIds,
     });
 
-    const loadedEvent = await this.runner.runSomeTests(files);
-    if (loadedEvent.suite) {
-      void this.fire(loadedEvent);
+    try {
+      const suiteOrError = await this.runner.runSomeTests(files);
+      if (typeof suiteOrError === "string") {
+        console.log("Error running tests", suiteOrError);
+        // TODO raise error into UI
+      } else {
+        void this.fire(suiteOrError);
+      }
+    } catch (err) {
+      console.log("Error running tests", err);
+    } finally {
+      this.testStatesEmitter.fire(<TestRunFinishedEvent>{ type: "finished" });
     }
-    this.testStatesEmitter.fire(<TestRunFinishedEvent>{ type: "finished" });
   }
 
-  private async fire(loadedEvent: TestLoadFinishedEvent): Promise<void> {
-    if (!loadedEvent.errorMessage && loadedEvent.suite) {
-      const suite = loadedEvent.suite;
-      await this.runner.fireEvents(suite, this.testStatesEmitter).then(() => {
-        void this.runner.fireDecorationEvents(suite, this.testStatesEmitter);
-        return true;
-      });
-      this.watch();
-    }
+  private async fire(suite: TestSuiteInfo): Promise<void> {
+    console.log("FW run", suite);
+    // TODO fire events directly out of runner
+    await this.runner.fireEvents(suite, this.testStatesEmitter);
+    this.watch();
   }
 
   private watch() {
@@ -170,4 +234,38 @@ export class ElmTestAdapter implements TestAdapter {
     }
     this.disposables = [];
   }
+}
+
+function toTestSuiteInfo(
+  suite: TestSuite,
+  parentId: string,
+): TestSuiteInfo | TestInfo {
+  const id = toId(parentId, suite);
+  return suite.tests && suite.tests.length > 0
+    ? {
+        type: "suite",
+        id,
+        label: toLabel(suite),
+        file: suite.file,
+        line: suite.position.line,
+        children: suite.tests.map((s) => toTestSuiteInfo(s, id)),
+      }
+    : {
+        type: "test",
+        id,
+        label: toLabel(suite),
+        file: suite.file,
+        line: suite.position.line,
+      };
+}
+
+function toLabel(suite: TestSuite): string {
+  return typeof suite.label === "string" ? suite.label : suite.label.join("..");
+}
+
+function toId(parentId: string, suite: TestSuite): string {
+  // TODO push into LSP?
+  return typeof suite.label === "string"
+    ? parentId + "/" + JSON.parse(suite.label)
+    : parentId + "/" + suite.label.map((l) => JSON.parse(l)).join("-");
 }

--- a/client/src/test-runner/adapter.ts
+++ b/client/src/test-runner/adapter.ts
@@ -22,7 +22,6 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 import * as vscode from "vscode";
-import { WorkspaceFolder } from "vscode";
 import { LanguageClient } from "vscode-languageclient/node";
 import {
   TestAdapter,
@@ -86,7 +85,7 @@ export class ElmTestAdapter implements TestAdapter {
     private readonly log: Log,
     configuredElmBinaries: () => IElmBinaries,
     private readonly getClient: (
-      folder: WorkspaceFolder,
+      folder: vscode.WorkspaceFolder,
     ) => LanguageClient | undefined,
   ) {
     this.log.info(
@@ -107,6 +106,7 @@ export class ElmTestAdapter implements TestAdapter {
     );
   }
 
+  // eslint-disable-next-line @typescript-eslint/require-await
   async load(): Promise<void> {
     if (this.isLoading) {
       return;

--- a/client/src/test-runner/adapter.ts
+++ b/client/src/test-runner/adapter.ts
@@ -115,8 +115,7 @@ export class ElmTestAdapter implements TestAdapter {
     this.isLoading = true;
 
     const input: IFindTestsParams = {
-      // workspaceRoot: this.workspace.uri.toString(),
-      workspaceRoot: this.elmProjectFolder.toString(),
+      projectFolder: this.elmProjectFolder.toString(),
     };
     try {
       const response = await this.client.sendRequest(FindTestsRequest, input);

--- a/client/src/test-runner/extension.ts
+++ b/client/src/test-runner/extension.ts
@@ -28,11 +28,14 @@ import { TestHub, testExplorerExtensionId } from "vscode-test-adapter-api";
 import { ElmTestAdapter } from "./adapter";
 import path = require("path");
 import { IElmBinaries } from "./util";
+import { LanguageClient } from "vscode-languageclient/node";
+import { WorkspaceFolder } from "vscode";
 
 export function activate(
   context: vscode.ExtensionContext,
   elmProjectFolder: vscode.Uri,
   configuredElmBinaries: () => IElmBinaries,
+  getClient: (folder: WorkspaceFolder) => LanguageClient | undefined,
 ): void {
   const workspaceFolder = (vscode.workspace.workspaceFolders || [])[0];
 
@@ -67,6 +70,7 @@ export function activate(
             elmProjectFolder,
             log,
             configuredElmBinaries,
+            getClient,
           ),
         log,
       ),

--- a/client/src/test-runner/extension.ts
+++ b/client/src/test-runner/extension.ts
@@ -22,59 +22,133 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 import * as vscode from "vscode";
-import { Log, TestAdapterRegistrar } from "vscode-test-adapter-util";
+import * as path from "path";
+import * as fs from "fs";
+
+import { Log } from "vscode-test-adapter-util";
 import { TestHub, testExplorerExtensionId } from "vscode-test-adapter-api";
 import { ElmTestAdapter } from "./adapter";
-import path = require("path");
-import { IElmBinaries } from "./util";
+
 import { LanguageClient } from "vscode-languageclient/node";
+
+class ElmTestAdapterRegister {
+  private readonly adapters: Map<string, Map<string, ElmTestAdapter>> = new Map(
+    [],
+  );
+
+  dispose(): void {
+    const adapters = Array.from(this.adapters.values()).flatMap((value) =>
+      Array.from(value.values()),
+    );
+    this.adapters.clear();
+    this.disposeAdapters(adapters);
+  }
+
+  private disposeAdapters(adapters: ElmTestAdapter[]): void {
+    const testHub = this.getTestHub();
+    if (testHub) {
+      adapters.forEach((adapter) => testHub.unregisterTestAdapter(adapter));
+    }
+    adapters.forEach((adapter) => adapter.dispose());
+  }
+
+  private getTestHub(): TestHub | undefined {
+    const testExplorerExtension = vscode.extensions.getExtension<TestHub>(
+      testExplorerExtensionId,
+    );
+    return testExplorerExtension ? testExplorerExtension.exports : undefined;
+  }
+
+  activate(
+    workspaceFolder: vscode.WorkspaceFolder,
+    client: LanguageClient,
+    log: Log,
+  ): void {
+    void client.onReady().then(() => {
+      const testHub = this.getTestHub();
+      log.info(`Test Explorer ${testHub ? "" : "not "}found`);
+
+      if (testHub) {
+        void vscode.workspace
+          .findFiles(
+            new vscode.RelativePattern(workspaceFolder, "**/elm.json"),
+            new vscode.RelativePattern(
+              workspaceFolder,
+              "**/{node_modules,elm-stuff}/**",
+            ),
+          )
+          .then((elmJsons) => {
+            elmJsons.forEach((elmJsonPath) => {
+              const elmProjectFolder = vscode.Uri.parse(
+                path.dirname(elmJsonPath.fsPath),
+              );
+              if (fs.existsSync(path.join(elmProjectFolder.fsPath, "tests"))) {
+                log.info(`Elm Test Runner for ${elmProjectFolder.fsPath}`);
+                const adapter = new ElmTestAdapter(
+                  workspaceFolder,
+                  elmProjectFolder,
+                  client,
+                  log,
+                );
+                this.add(workspaceFolder, elmProjectFolder, adapter);
+                testHub.registerTestAdapter(adapter);
+              }
+            });
+          });
+      }
+    });
+  }
+
+  private add(
+    workspaceFolder: vscode.WorkspaceFolder,
+    elmProjectFolder: vscode.Uri,
+    adapter: ElmTestAdapter,
+  ): void {
+    const key = workspaceFolder.uri.fsPath;
+    const subKey = elmProjectFolder.fsPath;
+    const value = this.adapters.get(key);
+    if (!value) {
+      const newValue = new Map<string, ElmTestAdapter>([[subKey, adapter]]);
+      this.adapters.set(key, newValue);
+      return;
+    }
+    value.set(subKey, adapter);
+  }
+
+  deactivate(workspaceFolder: vscode.WorkspaceFolder): void {
+    const key = workspaceFolder.uri.fsPath;
+    const value = this.adapters.get(key);
+    if (value) {
+      this.disposeAdapters(Array.from(value.values()));
+      this.adapters.delete(key);
+    }
+  }
+}
+
+let register: ElmTestAdapterRegister;
 
 export function activate(
   context: vscode.ExtensionContext,
-  elmProjectFolder: vscode.Uri,
-  configuredElmBinaries: () => IElmBinaries,
-  getClient: (folder: vscode.WorkspaceFolder) => LanguageClient | undefined,
+  workspaceFolder: vscode.WorkspaceFolder,
+  client: LanguageClient,
 ): void {
-  const workspaceFolder = (vscode.workspace.workspaceFolders || [])[0];
-
-  const relativeProjectFolder = path.relative(
-    workspaceFolder.uri.fsPath,
-    elmProjectFolder.fsPath,
-  );
+  if (!register) {
+    register = new ElmTestAdapterRegister();
+    context.subscriptions.push(register);
+  }
 
   const log = new Log(
     "elmTestRunner",
     workspaceFolder,
-    relativeProjectFolder.length > 0
-      ? `Elm Test Runner (${relativeProjectFolder})`
-      : "Elm Test Runner",
+    `Elm Test Runner (${workspaceFolder.name})`,
   );
   context.subscriptions.push(log);
 
-  const testExplorerExtension = vscode.extensions.getExtension<TestHub>(
-    testExplorerExtensionId,
-  );
-
-  log.info(`Test Explorer ${testExplorerExtension ? "" : "not "}found`);
-
-  if (testExplorerExtension) {
-    const testHub = testExplorerExtension.exports;
-    context.subscriptions.push(
-      new TestAdapterRegistrar(
-        testHub,
-        (workspaceFolder) =>
-          new ElmTestAdapter(
-            workspaceFolder,
-            elmProjectFolder,
-            log,
-            configuredElmBinaries,
-            getClient,
-          ),
-        log,
-      ),
-    );
-  }
+  register.activate(workspaceFolder, client, log);
 }
 
-// eslint-disable-next-line @typescript-eslint/no-empty-function
-export function deactivate(): void {}
+export function deactivate(workspaceFolder: vscode.WorkspaceFolder): void {
+  if (register) {
+    register.deactivate(workspaceFolder);
+  }
+}

--- a/client/src/test-runner/extension.ts
+++ b/client/src/test-runner/extension.ts
@@ -29,13 +29,12 @@ import { ElmTestAdapter } from "./adapter";
 import path = require("path");
 import { IElmBinaries } from "./util";
 import { LanguageClient } from "vscode-languageclient/node";
-import { WorkspaceFolder } from "vscode";
 
 export function activate(
   context: vscode.ExtensionContext,
   elmProjectFolder: vscode.Uri,
   configuredElmBinaries: () => IElmBinaries,
-  getClient: (folder: WorkspaceFolder) => LanguageClient | undefined,
+  getClient: (folder: vscode.WorkspaceFolder) => LanguageClient | undefined,
 ): void {
   const workspaceFolder = (vscode.workspace.workspaceFolders || [])[0];
 

--- a/client/src/test-runner/extension.ts
+++ b/client/src/test-runner/extension.ts
@@ -113,6 +113,13 @@ class ElmTestAdapterRegister {
       return;
     }
     value.set(subKey, adapter);
+
+    // TODO observe when elmProjectFolder gets deleted
+    // vscode.workspace.onDidDeleteFiles((e) => {
+    // });
+    // TODO observe when a new elmProjectFolder gets added
+    // vscode.workspace.onDidCreateFiles((e) => {
+    // });
   }
 
   deactivate(workspaceFolder: vscode.WorkspaceFolder): void {

--- a/client/src/test-runner/extension.ts
+++ b/client/src/test-runner/extension.ts
@@ -21,7 +21,6 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
-
 import * as vscode from "vscode";
 import { Log, TestAdapterRegistrar } from "vscode-test-adapter-util";
 import { TestHub, testExplorerExtensionId } from "vscode-test-adapter-api";

--- a/client/src/test-runner/result.ts
+++ b/client/src/test-runner/result.ts
@@ -127,9 +127,6 @@ function parseFailure(failure: any): Failure {
 export function parseErrorOutput(line: string): ErrorOutput {
   const errors: json.ParseError[] = [];
   const output: CompileErrors = json.parse(line, errors);
-  // const nojson = errors.find(
-  //   (e) => e.error === json.ParseErrorCode.InvalidSymbol,
-  // );
   if (output) {
     return output;
   }

--- a/client/src/test-runner/result.ts
+++ b/client/src/test-runner/result.ts
@@ -127,13 +127,13 @@ function parseFailure(failure: any): Failure {
 export function parseErrorOutput(line: string): ErrorOutput {
   const errors: json.ParseError[] = [];
   const output: CompileErrors = json.parse(line, errors);
-  const nojson = errors.find(
-    (e) => e.error === json.ParseErrorCode.InvalidSymbol,
-  );
-  if (errors.length > 0 && nojson) {
-    return { type: "message", line };
+  // const nojson = errors.find(
+  //   (e) => e.error === json.ParseErrorCode.InvalidSymbol,
+  // );
+  if (output) {
+    return output;
   }
-  return output;
+  return { type: "message", line };
 }
 
 export type Output = Message | Result;
@@ -245,11 +245,11 @@ export function buildErrorMessage(output: ErrorOutput): string {
     case "message":
       return output.line;
     case "compile-errors":
-      return buildCompileErrorsMessage(output.errors);
+      return buildCompileErrorsMessages(output.errors);
   }
 }
 
-function buildCompileErrorsMessage(errors: Error[]): string {
+function buildCompileErrorsMessages(errors: Error[]): string {
   return errors.map(buildCompileErrorMessage).join("\n\n");
 }
 

--- a/client/src/test-runner/runner.ts
+++ b/client/src/test-runner/runner.ts
@@ -106,27 +106,27 @@ export class ElmTestRunner {
     >,
   ): Promise<boolean> {
     if (node.type === "suite") {
-      testStatesEmitter.fire(<TestSuiteEvent>{
-        type: "suite",
-        suite: node.id,
-        state: "running",
-      });
+      // testStatesEmitter.fire(<TestSuiteEvent>{
+      //   type: "suite",
+      //   suite: node.id,
+      //   state: "running",
+      // });
 
       for (const child of node.children) {
         await this.fireEvents(child, testStatesEmitter);
       }
 
-      testStatesEmitter.fire(<TestSuiteEvent>{
-        type: "suite",
-        suite: node.id,
-        state: "completed",
-      });
+      // testStatesEmitter.fire(<TestSuiteEvent>{
+      //   type: "suite",
+      //   suite: node.id,
+      //   state: "completed",
+      // });
     } else {
-      testStatesEmitter.fire(<TestEvent>{
-        type: "test",
-        test: node.id,
-        state: "running",
-      });
+      // testStatesEmitter.fire(<TestEvent>{
+      //   type: "test",
+      //   test: node.id,
+      //   state: "running",
+      // });
 
       const event = this.eventById.get(node.id);
       if (!event) {
@@ -304,6 +304,8 @@ export class ElmTestRunner {
   private runElmTestWithReport(cwdPath: string, args: string[]) {
     this.log.info("Running Elm Tests", args);
 
+    this.eventById.clear();
+
     const argsWithReport = buildElmTestArgsWithReport(args);
     const elm = child_process.spawn(
       argsWithReport[0],
@@ -475,81 +477,81 @@ export class ElmTestRunner {
   }
 }
 
-function createTestEvent(
-  id: string,
-  event: EventTestCompleted,
-  lineOf: (text: string) => number,
-  line: number,
-): TestEvent {
-  switch (event.status.tag) {
-    case "pass":
-      return <TestEvent>{
-        type: "test",
-        test: id,
-        state: "passed",
-        line,
-      };
-    case "todo":
-      return <TestEvent>{
-        type: "test",
-        test: id,
-        state: "skipped",
-        line,
-      };
-    case "fail": {
-      const decorations: TestDecoration[] = createDecorations(
-        event.status,
-        lineOf,
-        line,
-      );
-      return <TestEvent>{
-        type: "test",
-        test: id,
-        state: "failed",
-        line,
-        decorations,
-      };
-    }
-  }
-}
+// function createTestEvent(
+//   id: string,
+//   event: EventTestCompleted,
+//   lineOf: (text: string) => number,
+//   line: number,
+// ): TestEvent {
+//   switch (event.status.tag) {
+//     case "pass":
+//       return <TestEvent>{
+//         type: "test",
+//         test: id,
+//         state: "passed",
+//         line,
+//       };
+//     case "todo":
+//       return <TestEvent>{
+//         type: "test",
+//         test: id,
+//         state: "skipped",
+//         line,
+//       };
+//     case "fail": {
+//       const decorations: TestDecoration[] = createDecorations(
+//         event.status,
+//         lineOf,
+//         line,
+//       );
+//       return <TestEvent>{
+//         type: "test",
+//         test: id,
+//         state: "failed",
+//         line,
+//         decorations,
+//       };
+//     }
+//   }
+// }
 
-function createDecorations(
-  status: TestStatus,
-  lineOf: (text: string) => number,
-  line?: number,
-): TestDecoration[] {
-  if (status.tag !== "fail") {
-    return [];
-  }
-  return status.failures.map((failure) => {
-    switch (failure.tag) {
-      case "comparison": {
-        const expected = oneLine(failure.expected);
-        const lineOfExpected = lineOf(failure.expected);
-        const actual = oneLine(failure.actual);
-        return <TestDecoration>{
-          line: lineOfExpected,
-          message: `${failure.comparison} ${expected} ${actual}`,
-        };
-      }
-      case "message": {
-        return <TestDecoration>{
-          line,
-          message: `${failure.message}`,
-        };
-      }
-      case "data": {
-        const message = Object.keys(failure.data)
-          .map((key) => `$(key): ${failure.data[key]}`)
-          .join("\n");
-        return <TestDecoration>{
-          line,
-          message,
-        };
-      }
-    }
-  });
-}
+// function createDecorations(
+//   status: TestStatus,
+//   lineOf: (text: string) => number,
+//   line?: number,
+// ): TestDecoration[] {
+//   if (status.tag !== "fail") {
+//     return [];
+//   }
+//   return status.failures.map((failure) => {
+//     switch (failure.tag) {
+//       case "comparison": {
+//         const expected = oneLine(failure.expected);
+//         const lineOfExpected = lineOf(failure.expected);
+//         const actual = oneLine(failure.actual);
+//         return <TestDecoration>{
+//           line: lineOfExpected,
+//           message: `${failure.comparison} ${expected} ${actual}`,
+//         };
+//       }
+//       case "message": {
+//         return <TestDecoration>{
+//           line,
+//           message: `${failure.message}`,
+//         };
+//       }
+//       case "data": {
+//         const message = Object.keys(failure.data)
+//           .map((key) => `$(key): ${failure.data[key]}`)
+//           .join("\n");
+//         return <TestDecoration>{
+//           line,
+//           message,
+//         };
+//       }
+//     }
+//   });
+// }
 
 function resolveElmBinaries(
   configured: IElmBinaries,

--- a/client/src/test-runner/runner.ts
+++ b/client/src/test-runner/runner.ts
@@ -88,6 +88,10 @@ export class ElmTestRunner {
     this.log.info("Running Elm Tests cancelled", this.relativeProjectFolder);
   }
 
+  get isBusy(): boolean {
+    return this.taskExecution !== undefined || this.process !== undefined;
+  }
+
   private get relativeProjectFolder(): string {
     return path.relative(
       this.workspaceFolder.uri.fsPath,

--- a/client/src/test-runner/runner.ts
+++ b/client/src/test-runner/runner.ts
@@ -143,7 +143,7 @@ export class ElmTestRunner {
     }
   }
 
-  async runSomeTests(files?: string[]): Promise<TestSuiteInfo | string> {
+  async runSomeTests(uris?: string[]): Promise<TestSuiteInfo | string> {
     return new Promise<TestSuiteInfo | string>((resolve) => {
       this.resolve = resolve;
       const relativePath = path.relative(
@@ -160,15 +160,15 @@ export class ElmTestRunner {
       };
       this.errorMessage = undefined;
       this.pendingMessages = [];
-      this.runElmTests(files);
+      this.runElmTests(uris);
     });
   }
 
-  private runElmTests(files?: string[]) {
+  private runElmTests(uris?: string[]) {
     const withOutput = vscode.workspace
       .getConfiguration("elmLS.elmTestRunner", null)
       .get("showElmTestOutput");
-    const args = this.elmTestArgs(files);
+    const args = this.elmTestArgs(uris);
     const cwdPath = this.elmProjectFolder.fsPath;
     if (withOutput) {
       this.runElmTestsWithOutput(cwdPath, args);
@@ -282,7 +282,8 @@ export class ElmTestRunner {
     });
   }
 
-  private elmTestArgs(files?: string[]): string[] {
+  private elmTestArgs(uris?: string[]): string[] {
+    const files = uris?.map((uri) => vscode.Uri.parse(uri).fsPath);
     return buildElmTestArgs(this.getElmBinaries(), files);
   }
 

--- a/client/src/test-runner/test/util.test.ts
+++ b/client/src/test-runner/test/util.test.ts
@@ -382,17 +382,32 @@ describe("util", () => {
       type: "suite",
       id: "top",
       label: "top",
+      file: "file1",
+      line: 1,
       children: [
         {
           type: "suite",
           id: "a/b",
           label: "b",
-          children: [],
+          file: "file2",
+          line: 2,
+          children: [
+            {
+              type: "suite",
+              id: "a/b/deep",
+              label: "deep",
+              file: "file2",
+              line: 22,
+              children: [],
+            },
+          ],
         },
         {
           type: "suite",
           id: "a/e",
           label: "e",
+          file: "file3",
+          line: 3,
           children: [],
         },
       ],
@@ -415,17 +430,32 @@ describe("util", () => {
         type: "suite",
         id: "top",
         label: "top",
+        file: "file1",
+        line: 1,
         children: [
           {
             type: "suite",
             id: "a/b",
             label: "b",
-            children: [],
+            file: "file2",
+            line: 2,
+            children: [
+              {
+                type: "suite",
+                id: "a/b/deep",
+                label: "deep",
+                file: "file2",
+                line: 22,
+                children: [],
+              },
+            ],
           },
           {
             type: "suite",
             id: "a/e",
             label: "e",
+            file: "file3",
+            line: 3,
             children: [],
           },
           {
@@ -463,17 +493,80 @@ describe("util", () => {
         type: "suite",
         id: "top",
         label: "top",
+        file: "file1",
+        line: 1,
         children: [
           {
             type: "suite",
             id: "a/b",
             label: "new b",
+            file: "file2",
+            line: 2,
             children: [],
           },
           {
             type: "suite",
             id: "a/e",
             label: "e",
+            file: "file3",
+            line: 3,
+            children: [],
+          },
+        ],
+      });
+    });
+
+    it("replace one and keep deep location", () => {
+      const from: TestSuiteInfo = {
+        type: "suite",
+        id: "top",
+        label: "top",
+        children: [
+          {
+            type: "suite",
+            id: "a/b",
+            label: "new b",
+            children: [
+              {
+                type: "suite",
+                id: "a/b/deep",
+                label: "new deep",
+                children: [],
+              },
+            ],
+          },
+        ],
+      };
+      expect(mergeTopLevelSuites(from, to)).to.eql({
+        type: "suite",
+        id: "top",
+        label: "top",
+        file: "file1",
+        line: 1,
+        children: [
+          {
+            type: "suite",
+            id: "a/b",
+            label: "new b",
+            file: "file2",
+            line: 2,
+            children: [
+              {
+                type: "suite",
+                id: "a/b/deep",
+                label: "new deep",
+                file: "file2",
+                line: 22,
+                children: [],
+              },
+            ],
+          },
+          {
+            type: "suite",
+            id: "a/e",
+            label: "e",
+            file: "file3",
+            line: 3,
             children: [],
           },
         ],
@@ -498,17 +591,32 @@ describe("util", () => {
         type: "suite",
         id: "top",
         label: "top",
+        file: "file1",
+        line: 1,
         children: [
           {
             type: "suite",
             id: "a/b",
             label: "b",
-            children: [],
+            file: "file2",
+            line: 2,
+            children: [
+              {
+                type: "suite",
+                id: "a/b/deep",
+                label: "deep",
+                file: "file2",
+                line: 22,
+                children: [],
+              },
+            ],
           },
           {
             type: "suite",
             id: "a/e",
             label: "e",
+            file: "file3",
+            line: 3,
             children: [],
           },
           {

--- a/client/src/test-runner/test/util.test.ts
+++ b/client/src/test-runner/test/util.test.ts
@@ -397,7 +397,7 @@ describe("util", () => {
         },
       ],
     };
-    test("mismatched", () => {
+    it("mismatched", () => {
       const from: TestSuiteInfo = {
         type: "suite",
         id: "another-top",
@@ -411,7 +411,114 @@ describe("util", () => {
           },
         ],
       };
-      expect(mergeTopLevelSuites(from, to)).to.be.eql({});
+      expect(mergeTopLevelSuites(from, to)).to.eql({
+        type: "suite",
+        id: "top",
+        label: "top",
+        children: [
+          {
+            type: "suite",
+            id: "a/b",
+            label: "b",
+            children: [],
+          },
+          {
+            type: "suite",
+            id: "a/e",
+            label: "e",
+            children: [],
+          },
+          {
+            type: "suite",
+            id: "another-top",
+            label: "another top",
+            children: [
+              {
+                type: "suite",
+                id: "c",
+                label: "c",
+                children: [],
+              },
+            ],
+          },
+        ],
+      });
+    });
+
+    it("replace one", () => {
+      const from: TestSuiteInfo = {
+        type: "suite",
+        id: "top",
+        label: "top",
+        children: [
+          {
+            type: "suite",
+            id: "a/b",
+            label: "new b",
+            children: [],
+          },
+        ],
+      };
+      expect(mergeTopLevelSuites(from, to)).to.eql({
+        type: "suite",
+        id: "top",
+        label: "top",
+        children: [
+          {
+            type: "suite",
+            id: "a/b",
+            label: "new b",
+            children: [],
+          },
+          {
+            type: "suite",
+            id: "a/e",
+            label: "e",
+            children: [],
+          },
+        ],
+      });
+    });
+
+    it("append one", () => {
+      const from: TestSuiteInfo = {
+        type: "suite",
+        id: "top",
+        label: "top",
+        children: [
+          {
+            type: "suite",
+            id: "a/d",
+            label: "new d",
+            children: [],
+          },
+        ],
+      };
+      expect(mergeTopLevelSuites(from, to)).to.eql({
+        type: "suite",
+        id: "top",
+        label: "top",
+        children: [
+          {
+            type: "suite",
+            id: "a/b",
+            label: "b",
+            children: [],
+          },
+          {
+            type: "suite",
+            id: "a/e",
+            label: "e",
+            children: [],
+          },
+          {
+            type: "suite",
+            id: "a/d",
+            label: "new d",
+            children: [],
+          },
+        ],
+      });
     });
   });
 });

--- a/client/src/test-runner/test/util.test.ts
+++ b/client/src/test-runner/test/util.test.ts
@@ -33,6 +33,7 @@ import {
   buildElmTestArgsWithReport,
   oneLine,
   getFilePath,
+  mergeTopLevelSuites,
 } from "../util";
 import { expect } from "chai";
 
@@ -373,6 +374,44 @@ describe("util", () => {
         duration: 13,
       });
       expect(path).to.eq("Module/Sub/Deep.elm");
+    });
+  });
+
+  describe("merge test suites", () => {
+    const to: TestSuiteInfo = {
+      type: "suite",
+      id: "top",
+      label: "top",
+      children: [
+        {
+          type: "suite",
+          id: "a/b",
+          label: "b",
+          children: [],
+        },
+        {
+          type: "suite",
+          id: "a/e",
+          label: "e",
+          children: [],
+        },
+      ],
+    };
+    test("mismatched", () => {
+      const from: TestSuiteInfo = {
+        type: "suite",
+        id: "another-top",
+        label: "another top",
+        children: [
+          {
+            type: "suite",
+            id: "c",
+            label: "c",
+            children: [],
+          },
+        ],
+      };
+      expect(mergeTopLevelSuites(from, to)).to.be.eql({});
     });
   });
 });

--- a/client/src/test-runner/util.ts
+++ b/client/src/test-runner/util.ts
@@ -23,7 +23,7 @@ SOFTWARE.
 */
 import { TestSuiteInfo, TestInfo } from "vscode-test-adapter-api";
 import { EventTestCompleted } from "./result";
-import * as vscode from "vscode";
+// import * as vscode from "vscode";
 
 export function* walk(
   node: TestSuiteInfo | TestInfo,
@@ -122,10 +122,10 @@ export function buildElmTestArgs(
   binaries: IElmBinaries,
   files?: string[],
 ): string[] {
-  const fs = files?.map((f) => vscode.Uri.parse(f).fsPath);
+  // const fs = files?.map((f) => vscode.Uri.parse(f).fsPath);
   return [binaries.elmTest ?? "elm-test"]
     .concat((binaries.elm && ["--compiler", binaries.elm]) ?? [])
-    .concat(fs ?? []);
+    .concat(files ?? []);
 }
 
 export function buildElmTestArgsWithReport(args: string[]): string[] {

--- a/client/src/test-runner/util.ts
+++ b/client/src/test-runner/util.ts
@@ -149,3 +149,25 @@ export function getFilePath(event: EventTestCompleted): string {
 export function getTestsRoot(elmProjectFolder: string): string {
   return `${elmProjectFolder}/tests`;
 }
+
+export function mergeTopLevelSuites(
+  from: TestSuiteInfo,
+  to: TestSuiteInfo,
+): TestSuiteInfo {
+  if (to.id === from.id) {
+    const byId: Map<string, TestSuiteInfo | TestInfo> = new Map(
+      from.children.map((node) => [node.id, node]),
+    );
+    const ids: Set<string> = new Set(to.children.map((c) => c.id));
+    const children = to.children.map((c) => byId.get(c.id) ?? c);
+    const news = Array.from(byId.values()).filter((e) => !ids.has(e.id));
+    return <TestSuiteInfo>{
+      ...to,
+      children: [...children, ...news],
+    };
+  }
+  return <TestSuiteInfo>{
+    ...to,
+    children: [...to.children, from],
+  };
+}

--- a/client/src/test-runner/util.ts
+++ b/client/src/test-runner/util.ts
@@ -21,9 +21,9 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
-import { Uri } from "vscode";
 import { TestSuiteInfo, TestInfo } from "vscode-test-adapter-api";
 import { EventTestCompleted } from "./result";
+import * as vscode from "vscode";
 
 export function* walk(
   node: TestSuiteInfo | TestInfo,
@@ -122,7 +122,7 @@ export function buildElmTestArgs(
   binaries: IElmBinaries,
   files?: string[],
 ): string[] {
-  const fs = files?.map((f) => Uri.parse(f).fsPath);
+  const fs = files?.map((f) => vscode.Uri.parse(f).fsPath);
   return [binaries.elmTest ?? "elm-test"]
     .concat((binaries.elm && ["--compiler", binaries.elm]) ?? [])
     .concat(fs ?? []);

--- a/client/src/test-runner/util.ts
+++ b/client/src/test-runner/util.ts
@@ -21,6 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
+import { Uri } from "vscode";
 import { TestSuiteInfo, TestInfo } from "vscode-test-adapter-api";
 import { EventTestCompleted } from "./result";
 
@@ -121,9 +122,10 @@ export function buildElmTestArgs(
   binaries: IElmBinaries,
   files?: string[],
 ): string[] {
+  const fs = files?.map((f) => Uri.parse(f).fsPath);
   return [binaries.elmTest ?? "elm-test"]
     .concat((binaries.elm && ["--compiler", binaries.elm]) ?? [])
-    .concat(files ?? []);
+    .concat(fs ?? []);
 }
 
 export function buildElmTestArgsWithReport(args: string[]): string[] {

--- a/client/src/test-runner/util.ts
+++ b/client/src/test-runner/util.ts
@@ -23,7 +23,6 @@ SOFTWARE.
 */
 import { TestSuiteInfo, TestInfo } from "vscode-test-adapter-api";
 import { EventTestCompleted } from "./result";
-// import * as vscode from "vscode";
 
 export function* walk(
   node: TestSuiteInfo | TestInfo,
@@ -122,7 +121,6 @@ export function buildElmTestArgs(
   binaries: IElmBinaries,
   files?: string[],
 ): string[] {
-  // const fs = files?.map((f) => vscode.Uri.parse(f).fsPath);
   return [binaries.elmTest ?? "elm-test"]
     .concat((binaries.elm && ["--compiler", binaries.elm]) ?? [])
     .concat(files ?? []);

--- a/client/src/test-runner/util.ts
+++ b/client/src/test-runner/util.ts
@@ -185,7 +185,6 @@ export function copyLocations(
   dest: TestSuiteInfo,
 ): TestSuiteInfo {
   const byId = new Map(Array.from(walk(source)).map((node) => [node.id, node]));
-
   const go = (node: TestSuiteInfo | TestInfo): TestSuiteInfo | TestInfo => {
     const found = byId.get(node.id);
     if (node.type === "suite") {

--- a/client/src/test-runner/util.ts
+++ b/client/src/test-runner/util.ts
@@ -104,10 +104,10 @@ export function mergeTopLevelSuites(
     );
     const ids: Set<string> = new Set(to.children.map((c) => c.id));
     const children = to.children.map((c) => byId.get(c.id) ?? c);
-    const news = Array.from(byId.values()).filter((e) => !ids.has(e.id));
+    const newSuites = Array.from(byId.values()).filter((e) => !ids.has(e.id));
     return <TestSuiteInfo>{
       ...to,
-      children: [...children, ...news],
+      children: [...children, ...newSuites],
     };
   }
   return <TestSuiteInfo>{

--- a/client/src/test-runner/util.ts
+++ b/client/src/test-runner/util.ts
@@ -112,6 +112,15 @@ export function getFilesAndAllTestIds(
   return [Array.from(selectedFiles), allIds];
 }
 
+export function getTestIdsForFile(
+  fileName: string,
+  suite: TestSuiteInfo,
+): string[] {
+  return Array.from(walk(suite))
+    .filter((node) => node.file === fileName)
+    .map((node) => node.id);
+}
+
 export interface IElmBinaries {
   elmTest?: string;
   elm?: string;


### PR DESCRIPTION
Use the new LS request to find tests at load time.
This PR explores the impact of using static analysis, via LS, on the integration with Test Explorer.

Goes with https://github.com/elm-tooling/elm-language-server/pull/583

Open questions:
- How to trigger the first load request when LS is ready to handle it?

Done
- match dynamic tests, run results win over loaded tests
- report errors from run
- fix handling of multiple elm folders inside a workspace (the current approach does not fit TestAdapterRegistrar semantics)

Todo:
- fix handling of multiple workspaces, blocked by https://github.com/elm-tooling/elm-language-client-vscode/issues/20?