### PR TITLE
Rescue locations

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "server"]
 	path = server
-	url = https://github.com/elm-tooling/elm-language-server.git
+	url = https://github.com/frawa/elm-language-server.git
+	branch = fix-missing-module-suite

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,3 @@
 [submodule "server"]
 	path = server
-	url = https://github.com/frawa/elm-language-server.git
-	branch = fix-missing-module-suite
+	url = https://github.com/elm-tooling/elm-language-server.git

--- a/client/src/test-runner/adapter.ts
+++ b/client/src/test-runner/adapter.ts
@@ -43,6 +43,7 @@ import { ElmTestRunner } from "./runner";
 import {
   copyLocations,
   getFilesAndAllTestIds,
+  getLineFun,
   getTestIdsForFile,
   getTestsRoot,
   mergeTopLevelSuites,
@@ -187,8 +188,8 @@ export class ElmTestAdapter implements TestAdapter {
         const suites = suiteOrError.children;
         const suite = this.getRootSuite(suites);
         this.loadedSuite = mergeTopLevelSuites(suite, this.loadedSuite);
-        this.fireRun(suiteOrError);
         this.fireLoaded(this.loadedSuite);
+        this.fireRun(suiteOrError, getLineFun(this.loadedSuite));
       }
     } catch (err) {
       console.log("Error running tests", err);
@@ -212,8 +213,11 @@ export class ElmTestAdapter implements TestAdapter {
     });
   }
 
-  private fireRun(suite: TestSuiteInfo): void {
-    this.runner.fireEvents(suite, this.testStatesEmitter);
+  private fireRun(
+    suite: TestSuiteInfo,
+    getLine: (id: string) => number | undefined,
+  ): void {
+    this.runner.fireEvents(suite, this.testStatesEmitter, getLine);
   }
 
   private watch() {

--- a/client/src/test-runner/runner.ts
+++ b/client/src/test-runner/runner.ts
@@ -146,16 +146,10 @@ export class ElmTestRunner {
   async runSomeTests(uris?: string[]): Promise<TestSuiteInfo | string> {
     return new Promise<TestSuiteInfo | string>((resolve) => {
       this.resolve = resolve;
-      const relativePath = path.relative(
-        this.workspaceFolder.uri.fsPath,
-        this.elmProjectFolder.fsPath,
-      );
-      const name =
-        relativePath.length > 0 ? relativePath : this.workspaceFolder.name;
       this.currentSuite = {
         type: "suite",
-        id: name,
-        label: name,
+        id: "",
+        label: "root",
         children: [],
       };
       this.errorMessage = undefined;

--- a/client/src/test-runner/runner.ts
+++ b/client/src/test-runner/runner.ts
@@ -50,7 +50,7 @@ import {
   buildElmTestArgsWithReport,
   getFilePath,
   getTestsRoot,
-  oneLine,
+  abreviateToOneLine,
 } from "./util";
 import { Log } from "vscode-test-adapter-util";
 import { IClientSettings } from "../extension";
@@ -456,8 +456,8 @@ function createDecorations(status: TestStatus, line: number): TestDecoration[] {
   return status.failures.map((failure) => {
     switch (failure.tag) {
       case "comparison": {
-        const expected = oneLine(failure.expected);
-        const actual = oneLine(failure.actual);
+        const expected = abreviateToOneLine(failure.expected);
+        const actual = abreviateToOneLine(failure.actual);
         return <TestDecoration>{
           line: line,
           message: `${failure.comparison} ${expected} ${actual}`,

--- a/client/src/test-runner/util.ts
+++ b/client/src/test-runner/util.ts
@@ -149,7 +149,7 @@ export function getLineFun(
   return (id: string) => byId.get(id);
 }
 
-export function oneLine(text: string): string {
+export function abreviateToOneLine(text: string): string {
   const text1 = text.split("\n").join(" ");
   if (text1.length > 20) {
     return text1.substr(0, 20) + " ...";

--- a/client/src/test-runner/util.ts
+++ b/client/src/test-runner/util.ts
@@ -137,3 +137,22 @@ export function copyLocations(
     ? { ...dest, children, file: found.file, line: found.line }
     : { ...dest, children };
 }
+
+export function getLineFun(
+  suite: TestSuiteInfo,
+): (id: string) => number | undefined {
+  const byId = new Map(
+    Array.from(walk(suite))
+      .filter((node) => node.line !== undefined)
+      .map((node) => [node.id, node.line]),
+  );
+  return (id: string) => byId.get(id);
+}
+
+export function oneLine(text: string): string {
+  const text1 = text.split("\n").join(" ");
+  if (text1.length > 20) {
+    return text1.substr(0, 20) + " ...";
+  }
+  return text1;
+}


### PR DESCRIPTION
Goes with https://github.com/elm-tooling/elm-language-server/pull/592

Fix how locations are matched across loads and runs.

Also
- decorate test failures, where possible
- improve how errors are raised into Test Explorer UI
