### PR TITLE
Start if an elm.json is found, not on entering an elm file

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -10,11 +10,11 @@ import {
   Position,
   ProviderResult,
   Range,
+  RelativePattern,
   TextDocument,
   Uri,
   window as Window,
   workspace as Workspace,
-  WorkspaceFolder,
 } from "vscode";
 import {
   LanguageClientOptions,
@@ -62,128 +62,74 @@ export interface IRefactorCodeAction extends Omit<CodeAction, "isPreferred"> {
 
 const clients: Map<string, LanguageClient> = new Map<string, LanguageClient>();
 
-let sortedWorkspaceFolders: string[] | undefined;
-
-function getSortedWorkspaceFolders(): string[] {
-  if (sortedWorkspaceFolders === void 0) {
-    sortedWorkspaceFolders = Workspace.workspaceFolders
-      ? Workspace.workspaceFolders
-          .map((folder) => {
-            let result = folder.uri.toString();
-            if (result.charAt(result.length - 1) !== "/") {
-              result = result + "/";
-            }
-            return result;
-          })
-          .sort((a, b) => {
-            return a.length - b.length;
-          })
-      : [];
-  }
-  return sortedWorkspaceFolders;
-}
-Workspace.onDidChangeWorkspaceFolders(
-  () => (sortedWorkspaceFolders = undefined),
-);
-
-function getOuterMostWorkspaceFolder(
-  folder: WorkspaceFolder,
-): WorkspaceFolder | undefined {
-  const sorted = getSortedWorkspaceFolders();
-  for (const element of sorted) {
-    let uri = folder.uri.toString();
-    if (uri.charAt(uri.length - 1) !== "/") {
-      uri = uri + "/";
-    }
-    if (uri.startsWith(element)) {
-      return Workspace.getWorkspaceFolder(Uri.parse(element));
-    }
-  }
-  return folder;
-}
-
 export function activate(context: ExtensionContext): void {
   const module = context.asAbsolutePath(path.join("server", "out", "index.js"));
 
-  function didOpenTextDocument(document: TextDocument) {
-    // We are only interested in everything elm, no handling for untitled files for now
-    if (document.languageId !== "elm") {
-      return;
-    }
+  const config = Workspace.getConfiguration().get<IClientSettings>("elmLS");
 
-    const config = Workspace.getConfiguration().get<IClientSettings>("elmLS");
+  // If we have nested workspace folders we only start a server on the outer most workspace folder.
+  void Workspace.findFiles(
+    "**/elm.json",
+    "**/{node_modules,elm-stuff}/**",
+  ).then((workspaceFolders) => {
+    workspaceFolders.forEach((workspaceFolderUri) => {
+      const workspaceFolder = Workspace.getWorkspaceFolder(workspaceFolderUri);
+      if (workspaceFolder && !clients.has(workspaceFolder.uri.toString())) {
+        const relativeWorkspace = workspaceFolder.name;
+        const outputChannel: OutputChannel = Window.createOutputChannel(
+          relativeWorkspace.length > 0 ? `Elm (${relativeWorkspace})` : "Elm",
+        );
 
-    const uri = document.uri;
-    let folder = Workspace.getWorkspaceFolder(uri);
-    // Files outside a folder can't be handled. This might depend on the language.
-    // Single file languages like JSON might handle files outside the workspace folders.
-    if (!folder) {
-      return;
-    }
-    // If we have nested workspace folders we only start a server on the outer most workspace folder.
-    folder = getOuterMostWorkspaceFolder(folder);
-
-    if (!folder) {
-      return;
-    }
-
-    if (!clients.has(folder.uri.toString())) {
-      const relativeWorkspace = folder.name;
-      const outputChannel: OutputChannel = Window.createOutputChannel(
-        relativeWorkspace.length > 0 ? `Elm (${relativeWorkspace})` : "Elm",
-      );
-
-      const debugOptions = {
-        execArgv: ["--nolazy", `--inspect=${6010 + clients.size}`],
-      };
-      const serverOptions: ServerOptions = {
-        debug: {
-          module,
-          options: debugOptions,
-          transport: TransportKind.ipc,
-        },
-        run: {
-          module,
-          transport: TransportKind.ipc,
-        },
-      };
-      const clientOptions: LanguageClientOptions = {
-        diagnosticCollectionName: "Elm",
-        documentSelector: [
-          {
-            language: "elm",
-            pattern: `${folder.uri.fsPath}/**/*`,
-            scheme: "file",
+        const debugOptions = {
+          execArgv: ["--nolazy", `--inspect=${6010 + clients.size}`],
+        };
+        const serverOptions: ServerOptions = {
+          debug: {
+            module,
+            options: debugOptions,
+            transport: TransportKind.ipc,
           },
-        ],
-        synchronize: {
-          fileEvents: Workspace.createFileSystemWatcher("**/*.elm"),
-        },
-        initializationOptions: getSettings(config),
-        middleware: new CodeLensResolver(),
-        outputChannel,
-        progressOnInitialization: true,
-        revealOutputChannelOn: RevealOutputChannelOn.Never,
-        workspaceFolder: folder,
-      };
-      const client = new LanguageClient(
-        "elmLS",
-        "Elm",
-        serverOptions,
-        clientOptions,
-      );
-      client.start();
-      clients.set(folder.uri.toString(), client);
+          run: {
+            module,
+            transport: TransportKind.ipc,
+          },
+        };
+        const clientOptions: LanguageClientOptions = {
+          diagnosticCollectionName: "Elm",
+          documentSelector: [
+            {
+              language: "elm",
+              pattern: `${workspaceFolder.uri.fsPath}/**/*`,
+              scheme: "file",
+            },
+          ],
+          synchronize: {
+            fileEvents: Workspace.createFileSystemWatcher("**/*.elm"),
+          },
+          initializationOptions: getSettings(config),
+          middleware: new CodeLensResolver(),
+          outputChannel,
+          progressOnInitialization: true,
+          revealOutputChannelOn: RevealOutputChannelOn.Never,
+          workspaceFolder,
+        };
+        const client = new LanguageClient(
+          "elmLS",
+          "Elm",
+          serverOptions,
+          clientOptions,
+        );
+        client.start();
+        clients.set(workspaceFolder.uri.toString(), client);
 
-      RefactorAction.registerCommands(client, context);
-      ExposeUnexposeAction.registerCommands(client, context);
+        RefactorAction.registerCommands(client, context);
+        ExposeUnexposeAction.registerCommands(client, context);
 
-      TestRunner.activate(context, folder, client);
-    }
-  }
+        TestRunner.activate(context, workspaceFolder, client);
+      }
+    });
+  });
 
-  Workspace.onDidOpenTextDocument(didOpenTextDocument);
-  Workspace.textDocuments.forEach(didOpenTextDocument);
   Workspace.onDidChangeWorkspaceFolders(async (event) => {
     for (const folder of event.removed) {
       const client = clients.get(folder.uri.toString());

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "vscode": "^1.52.0"
   },
   "activationEvents": [
-    "onLanguage:elm",
     "workspaceContains:**/elm.json"
   ],
   "main": "./client/out/extension",


### PR DESCRIPTION
This seems to be nicer now, that you might want to directly go to the test page.

We basically look for an `elm.json` and then start an elm server for each workspace, that's available and has an `elm.json` somewhere.
We only ever start one server per workspace, like before. 

This will need as much testing as possible.

Unfortunatly, I couldn't find a way to watch for a newly created `elm.json` file to trigger this. At least not via a filesystem api.