### PR TITLE
Clarify responsibilities for runner

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -15,7 +15,8 @@
   "scripts": {
     "compile": "tsc -p ./",
     "lint": "eslint -c .eslintrc.js --ext .ts src",
-    "test": "nyc --reporter=lcovonly --reporter=text mocha"
+    "test": "nyc --reporter=lcovonly --reporter=text mocha",
+    "test:watch": "mocha --watch"
   },
   "dependencies": {
     "jsonc-parser": "^3.0.0",

--- a/client/package.json
+++ b/client/package.json
@@ -27,7 +27,8 @@
   },
   "mocha": {
     "require": "ts-node/register",
-    "spec": "src/**/*.test.ts"
+    "spec": "src/**/*.test.ts",
+    "watch-files": "src/**/*.ts"
   },
   "devDependencies": {
     "@types/chai": "^4.2.16",

--- a/client/src/test-runner/result.ts
+++ b/client/src/test-runner/result.ts
@@ -42,14 +42,14 @@ export function parseOutput(line: string): Output {
 
 export function parseResult(parsed: any): Result {
   if ((parsed.event as string) === "runStart") {
-    const event: Event = {
+    const event: RunEvent = {
       tag: "runStart",
       testCount: Number.parseInt(parsed.testCount),
     };
     return { type: "result", event };
   }
   if (parsed.event === "runComplete") {
-    const event: Event = {
+    const event: RunEvent = {
       tag: "runComplete",
       passed: Number.parseInt(parsed.passed),
       failed: Number.parseInt(parsed.failed),
@@ -62,7 +62,7 @@ export function parseResult(parsed: any): Result {
     if (status) {
       const messages: string[] =
         (parsed.messages as string[])?.map((m: string) => String(m)) ?? [];
-      const event: Event = {
+      const event: RunEvent = {
         tag: "testCompleted",
         labels: parsed.labels as string[],
         messages,
@@ -144,15 +144,15 @@ export type Message = {
 
 export type Result = {
   type: "result";
-  event: Event;
+  event: RunEvent;
 };
 
-export type Event =
+export type RunEvent =
   | { tag: "runStart"; testCount: number }
-  | EventTestCompleted
+  | TestCompleted
   | { tag: "runComplete"; passed: number; failed: number; duration: number };
 
-export type EventTestCompleted = {
+export type TestCompleted = {
   tag: "testCompleted";
   labels: string[];
   messages: string[];
@@ -211,7 +211,7 @@ export type StyledString = {
   string: string;
 };
 
-export function buildMessage(event: EventTestCompleted): string | undefined {
+export function buildMessage(event: TestCompleted): string | undefined {
   if (event.status.tag === "fail") {
     const lines = event.status.failures.flatMap((failure) => {
       switch (failure.tag) {

--- a/client/src/test-runner/runTestSuite.ts
+++ b/client/src/test-runner/runTestSuite.ts
@@ -40,16 +40,10 @@ export type RunTestData = {
   data: TestCompleted;
 };
 
-export type RunTestError = {
-  type: "error";
-  message: string;
-  id: string;
-};
-
 export function insertRunTestData(
   suite: RunTestSuite,
   data: TestCompleted,
-): RunTestSuite | RunTestError {
+): RunTestSuite {
   return doInsertRunTestData(suite, [...data.labels], data);
 }
 

--- a/client/src/test-runner/runTestSuite.ts
+++ b/client/src/test-runner/runTestSuite.ts
@@ -70,10 +70,12 @@ function doInsertRunTestData(
       throw new Error(`duplicate id '${testData.id}'`);
     }
   }
+
   const labels1 = [...labels];
   const label = labels1.shift();
   if (label === undefined) {
-    throw new Error("???");
+    // this cannot happen, but it makes TS happy
+    return suite;
   }
 
   const exists = suite.children.some((child) => child.label === label);

--- a/client/src/test-runner/runTestSuite.ts
+++ b/client/src/test-runner/runTestSuite.ts
@@ -27,17 +27,17 @@ import { TestCompleted } from "./result";
 export type RunTestItem = RunTestSuite | RunTestData;
 
 export type RunTestSuite = {
-  type: "suite";
-  id: string;
-  label: string;
-  children: RunTestItem[];
+  readonly type: "suite";
+  readonly id: string;
+  readonly label: string;
+  readonly children: readonly RunTestItem[];
 };
 
 export type RunTestData = {
-  type: "test";
-  id: string;
-  label: string;
-  data: TestCompleted;
+  readonly type: "test";
+  readonly id: string;
+  readonly label: string;
+  readonly data: TestCompleted;
 };
 
 export function insertRunTestData(

--- a/client/src/test-runner/runTestSuite.ts
+++ b/client/src/test-runner/runTestSuite.ts
@@ -1,0 +1,108 @@
+/*
+MIT License
+
+ Copyright 2021 Frank Wagner
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+import { TestCompleted } from "./result";
+
+export type RunTestItem = RunTestSuite | RunTestData;
+
+export type RunTestSuite = {
+  type: "suite";
+  id: string;
+  label: string;
+  children: RunTestItem[];
+};
+
+export type RunTestData = {
+  type: "test";
+  id: string;
+  label: string;
+  data: TestCompleted;
+};
+
+export type RunTestError = {
+  type: "error";
+  message: string;
+  id: string;
+};
+
+export function insertRunTestData(
+  suite: RunTestSuite,
+  data: TestCompleted,
+): RunTestSuite | RunTestError {
+  return doInsertRunTestData(suite, [...data.labels], data);
+}
+
+function doInsertRunTestData(
+  suite: RunTestSuite,
+  labels: string[],
+  data: TestCompleted,
+): RunTestSuite {
+  if (labels.length === 1) {
+    const label = labels[0];
+    const testData: RunTestData = {
+      type: "test",
+      id: `${suite.id}/${label}`,
+      label,
+      data,
+    };
+    const exists = suite.children.some((child) => child.label === label);
+    if (!exists) {
+      return {
+        ...suite,
+        children: [...suite.children, testData],
+      };
+    } else {
+      throw new Error(`duplicate id '${testData.id}'`);
+    }
+  }
+  const labels1 = [...labels];
+  const label = labels1.shift();
+  if (label === undefined) {
+    throw new Error("???");
+  }
+
+  const exists = suite.children.some((child) => child.label === label);
+  if (!exists) {
+    const newSuite: RunTestSuite = {
+      type: "suite",
+      id: `${suite.id}/${label}`,
+      label,
+      children: [],
+    };
+    return {
+      ...suite,
+      children: [
+        ...suite.children,
+        doInsertRunTestData(newSuite, labels1, data),
+      ],
+    };
+  } else {
+    const children = suite.children.map((child) =>
+      child.type === "suite" && child.label === label
+        ? doInsertRunTestData(child, labels1, data)
+        : child,
+    );
+    return { ...suite, children };
+  }
+}

--- a/client/src/test-runner/runner.ts
+++ b/client/src/test-runner/runner.ts
@@ -22,38 +22,25 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 import * as vscode from "vscode";
-import {
-  TestSuiteInfo,
-  TestInfo,
-  TestRunStartedEvent,
-  TestRunFinishedEvent,
-  TestSuiteEvent,
-  TestEvent,
-  TestDecoration,
-} from "vscode-test-adapter-api";
 import path = require("path");
 import * as child_process from "child_process";
 import * as fs from "fs";
 
 import {
   Result,
-  buildMessage,
   parseOutput,
   parseErrorOutput,
   buildErrorMessage,
   TestCompleted,
-  TestStatus,
 } from "./result";
 import {
   IElmBinaries,
   buildElmTestArgs,
   buildElmTestArgsWithReport,
-  getFilePath,
-  getTestsRoot,
-  abreviateToOneLine,
 } from "./util";
 import { Log } from "vscode-test-adapter-util";
 import { IClientSettings } from "../extension";
+import { insertRunTestData, RunTestSuite } from "./runTestSuite";
 
 export class ElmTestRunner {
   private eventById: Map<string, TestCompleted> = new Map<
@@ -63,11 +50,11 @@ export class ElmTestRunner {
 
   private running = false;
   private resolve?: (
-    value: TestSuiteInfo | string | PromiseLike<TestSuiteInfo | string>,
+    value: RunTestSuite | string | PromiseLike<RunTestSuite | string>,
     // eslint-disable-next-line @typescript-eslint/no-empty-function
   ) => void = undefined;
 
-  private currentSuite?: TestSuiteInfo = undefined;
+  private currentSuite?: RunTestSuite = undefined;
   private errorMessage?: string = undefined;
   private pendingMessages: string[] = [];
 
@@ -91,7 +78,7 @@ export class ElmTestRunner {
     return this.running;
   }
 
-  private finish(result: TestSuiteInfo | string): void {
+  private finish(result: RunTestSuite | string): void {
     this.log.debug("Running Elm Tests finished");
     this.resolve?.(result);
     this.stopIt();
@@ -115,69 +102,12 @@ export class ElmTestRunner {
     );
   }
 
-  fireEvents(
-    node: TestSuiteInfo | TestInfo,
-    testStatesEmitter: vscode.EventEmitter<
-      TestRunStartedEvent | TestRunFinishedEvent | TestSuiteEvent | TestEvent
-    >,
-    getLine: (id: string) => number | undefined,
-  ): void {
-    if (node.type === "suite") {
-      for (const child of node.children) {
-        this.fireEvents(child, testStatesEmitter, getLine);
-      }
-    } else {
-      const event = this.eventById.get(node.id);
-      if (!event) {
-        throw new Error(`result for ${node.id}?`);
-      }
-      const message = buildMessage(event);
-      switch (event.status.tag) {
-        case "pass": {
-          testStatesEmitter.fire(<TestEvent>{
-            type: "test",
-            test: node.id,
-            state: "passed",
-            message,
-            description: `${event.duration}s`,
-          });
-          break;
-        }
-        case "todo": {
-          testStatesEmitter.fire(<TestEvent>{
-            type: "test",
-            test: node.id,
-            state: "skipped",
-            message,
-          });
-          break;
-        }
-        case "fail": {
-          const line = getLine(node.id);
-          const decorations: TestDecoration[] | undefined =
-            line !== undefined
-              ? createDecorations(event.status, line)
-              : undefined;
-          testStatesEmitter.fire(<TestEvent>{
-            type: "test",
-            test: node.id,
-            file: node.file,
-            state: "failed",
-            message,
-            decorations,
-          });
-          break;
-        }
-      }
-    }
-  }
-
-  async runSomeTests(uris?: string[]): Promise<TestSuiteInfo | string> {
+  async runSomeTests(uris?: string[]): Promise<RunTestSuite | string> {
     if (this.running) {
       return Promise.reject("already running");
     }
     this.running = true;
-    return new Promise<TestSuiteInfo | string>((resolve) => {
+    return new Promise<RunTestSuite | string>((resolve) => {
       this.resolve = resolve;
       this.currentSuite = {
         type: "suite",
@@ -381,9 +311,9 @@ export class ElmTestRunner {
           ...result.event,
           messages: this.popMessages(),
         };
-        const labels: string[] = [...event.labels];
-        const id = this.addEvent(this.currentSuite, labels, event);
-        this.eventById.set(id, event);
+        // const labels: string[] = [...event.labels];
+        this.currentSuite = insertRunTestData(this.currentSuite, event);
+        // this.eventById.set(id, event);
         break;
       }
       case "runStart":
@@ -391,56 +321,6 @@ export class ElmTestRunner {
       case "runComplete":
         break;
     }
-  }
-
-  private addEvent(
-    suite: TestSuiteInfo,
-    labels: string[],
-    event: TestCompleted,
-  ): string {
-    if (labels.length === 1) {
-      let testInfo: TestInfo = {
-        type: "test",
-        id: suite.id + "/" + labels[0],
-        label: labels[0],
-        file: this.getFilePath(event),
-      };
-      if (event.status.tag === "todo") {
-        testInfo = {
-          ...testInfo,
-          skipped: true,
-        };
-      }
-      suite.children.push(testInfo);
-      return testInfo.id;
-    }
-
-    const label = labels.shift();
-
-    if (!label) {
-      throw new Error("empty labels?");
-    }
-
-    const found = suite.children.find((child) => child.label === label);
-    if (found && found.type === "suite") {
-      return this.addEvent(found, labels, event);
-    }
-
-    const newSuite: TestSuiteInfo = {
-      type: "suite",
-      id: suite.id + "/" + label,
-      label: label,
-      children: [],
-      file: this.getFilePath(event),
-    };
-    suite.children.push(newSuite);
-    return this.addEvent(newSuite, labels, event);
-  }
-
-  private getFilePath(event: TestCompleted): string {
-    const path = getFilePath(event);
-    const testsRoot = getTestsRoot(this.elmProjectFolder.fsPath);
-    return `${testsRoot}/${path}`;
   }
 }
 
@@ -471,37 +351,4 @@ function findLocalNpmBinary(
 
 function nonEmpty(text: string | undefined): string | undefined {
   return text && text.length > 0 ? text : undefined;
-}
-
-function createDecorations(status: TestStatus, line: number): TestDecoration[] {
-  if (status.tag !== "fail") {
-    return [];
-  }
-  return status.failures.map((failure) => {
-    switch (failure.tag) {
-      case "comparison": {
-        const expected = abreviateToOneLine(failure.expected);
-        const actual = abreviateToOneLine(failure.actual);
-        return <TestDecoration>{
-          line: line,
-          message: `${failure.comparison} ${expected} ${actual}`,
-        };
-      }
-      case "message": {
-        return <TestDecoration>{
-          line,
-          message: `${failure.message}`,
-        };
-      }
-      case "data": {
-        const message = Object.keys(failure.data)
-          .map((key) => `$(key): ${failure.data[key]}`)
-          .join("\n");
-        return <TestDecoration>{
-          line,
-          message,
-        };
-      }
-    }
-  });
 }

--- a/client/src/test-runner/runner.ts
+++ b/client/src/test-runner/runner.ts
@@ -41,7 +41,7 @@ import {
   parseOutput,
   parseErrorOutput,
   buildErrorMessage,
-  EventTestCompleted,
+  TestCompleted,
   TestStatus,
 } from "./result";
 import {
@@ -56,9 +56,9 @@ import { Log } from "vscode-test-adapter-util";
 import { IClientSettings } from "../extension";
 
 export class ElmTestRunner {
-  private eventById: Map<string, EventTestCompleted> = new Map<
+  private eventById: Map<string, TestCompleted> = new Map<
     string,
-    EventTestCompleted
+    TestCompleted
   >();
 
   private running = false;
@@ -377,7 +377,7 @@ export class ElmTestRunner {
         if (!this.currentSuite) {
           throw new Error("not loading?");
         }
-        const event: EventTestCompleted = {
+        const event: TestCompleted = {
           ...result.event,
           messages: this.popMessages(),
         };
@@ -396,7 +396,7 @@ export class ElmTestRunner {
   private addEvent(
     suite: TestSuiteInfo,
     labels: string[],
-    event: EventTestCompleted,
+    event: TestCompleted,
   ): string {
     if (labels.length === 1) {
       let testInfo: TestInfo = {
@@ -437,7 +437,7 @@ export class ElmTestRunner {
     return this.addEvent(newSuite, labels, event);
   }
 
-  private getFilePath(event: EventTestCompleted): string {
+  private getFilePath(event: TestCompleted): string {
     const path = getFilePath(event);
     const testsRoot = getTestsRoot(this.elmProjectFolder.fsPath);
     return `${testsRoot}/${path}`;

--- a/client/src/test-runner/runner.ts
+++ b/client/src/test-runner/runner.ts
@@ -62,25 +62,24 @@ export class ElmTestRunner implements vscode.Disposable {
   ) {}
 
   dispose(): void {
-    this.stopIt();
+    this.cancel();
   }
 
-  cancel(): void {
-    this.resolve?.("cancelled");
-    this.stopIt();
-    this.log.info("Running Elm Tests cancelled", this.relativeProjectFolder);
+  private cancel(): void {
+    if (this.resolve) {
+      this.log.info("Running Elm Tests cancelled", this.relativeProjectFolder);
+      this.resolve("cancelled");
+    }
+    this.taskExecution?.terminate();
+    this.process?.kill();
+    this.disposables.forEach((d) => void d.dispose());
   }
 
   private finish(result: RunTestSuite | string): void {
     this.log.debug("Running Elm Tests finished");
     this.resolve?.(result);
-    this.stopIt();
-  }
-
-  private stopIt(): void {
-    this.taskExecution?.terminate();
-    this.process?.kill();
-    this.disposables.forEach((d) => void d.dispose());
+    this.resolve = undefined;
+    this.cancel();
   }
 
   private get relativeProjectFolder(): string {

--- a/client/src/test-runner/runner.ts
+++ b/client/src/test-runner/runner.ts
@@ -296,9 +296,7 @@ export class ElmTestRunner implements vscode.Disposable {
           ...result.event,
           messages: this.popMessages(),
         };
-        // const labels: string[] = [...event.labels];
         this.currentSuite = insertRunTestData(this.currentSuite, event);
-        // this.eventById.set(id, event);
         break;
       }
       case "runStart":

--- a/client/src/test-runner/runner.ts
+++ b/client/src/test-runner/runner.ts
@@ -43,11 +43,6 @@ import { IClientSettings } from "../extension";
 import { insertRunTestData, RunTestSuite } from "./runTestSuite";
 
 export class ElmTestRunner {
-  private eventById: Map<string, TestCompleted> = new Map<
-    string,
-    TestCompleted
-  >();
-
   private running = false;
   private resolve?: (
     value: RunTestSuite | string | PromiseLike<RunTestSuite | string>,
@@ -188,8 +183,6 @@ export class ElmTestRunner {
 
   private runElmTestWithReport(cwdPath: string, args: string[]) {
     this.log.info("Running Elm Tests", args);
-
-    this.eventById.clear();
 
     const argsWithReport = buildElmTestArgsWithReport(args);
     const elm = child_process.spawn(

--- a/client/src/test-runner/test/result.test.ts
+++ b/client/src/test-runner/test/result.test.ts
@@ -29,7 +29,7 @@ import {
   buildMessage,
   parseErrorOutput,
   Output,
-  EventTestCompleted,
+  TestCompleted,
   parseResult,
 } from "../result";
 
@@ -156,7 +156,7 @@ describe("result", () => {
         messages: ["hello", "world"],
         duration: "13",
       };
-      const event: EventTestCompleted = {
+      const event: TestCompleted = {
         tag: "testCompleted",
         labels: ["suite", "test"],
         messages: ["hello", "world"],
@@ -189,7 +189,7 @@ describe("result", () => {
         messages: [],
         duration: "0",
       };
-      const event: EventTestCompleted = {
+      const event: TestCompleted = {
         tag: "testCompleted",
         labels: ["suite", "test"],
         messages: [],
@@ -231,7 +231,7 @@ describe("result", () => {
         messages: [],
         duration: "0",
       };
-      const event: EventTestCompleted = {
+      const event: TestCompleted = {
         tag: "testCompleted",
         labels: ["suite", "test"],
         messages: [],
@@ -276,7 +276,7 @@ describe("result", () => {
         messages: [],
         duration: "0",
       };
-      const event: EventTestCompleted = {
+      const event: TestCompleted = {
         tag: "testCompleted",
         labels: ["suite", "test"],
         messages: [],
@@ -323,7 +323,7 @@ describe("result", () => {
         messages: [],
         duration: "0",
       };
-      const event: EventTestCompleted = {
+      const event: TestCompleted = {
         tag: "testCompleted",
         labels: ["suite", "test"],
         messages: [],
@@ -373,7 +373,7 @@ describe("result", () => {
         messages: [],
         duration: "0",
       };
-      const event: EventTestCompleted = {
+      const event: TestCompleted = {
         tag: "testCompleted",
         labels: ["suite", "test"],
         messages: [],
@@ -422,7 +422,7 @@ describe("result", () => {
       messages: ["broken"],
       duration: "0",
     };
-    const event: EventTestCompleted = {
+    const event: TestCompleted = {
       tag: "testCompleted",
       labels: ["suite", "test"],
       messages: ["broken"],
@@ -458,7 +458,7 @@ function expectResult(output: Output, fun: (result: Result) => void) {
   }
 }
 
-function expectEvent(result: Result, fun: (event: EventTestCompleted) => void) {
+function expectEvent(result: Result, fun: (event: TestCompleted) => void) {
   expect(result.event.tag).to.eq("testCompleted");
   if (result?.event.tag === "testCompleted") {
     fun(result.event);

--- a/client/src/test-runner/test/runTestSuite.test.ts
+++ b/client/src/test-runner/test/runTestSuite.test.ts
@@ -1,0 +1,167 @@
+/*
+MIT License
+
+ Copyright 2021 Frank Wagner
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+import { expect } from "chai";
+import { TestCompleted } from "../result";
+import { insertRunTestData, RunTestSuite } from "../runTestSuite";
+
+describe("run test suite", () => {
+  const empty: RunTestSuite = {
+    type: "suite",
+    id: "top",
+    label: "top",
+    children: [],
+  };
+
+  it("empty", () => {
+    const data: TestCompleted = {
+      tag: "testCompleted",
+      labels: ["Module", "test"],
+      messages: [],
+      duration: 0,
+      status: { tag: "pass" },
+    };
+    const top = insertRunTestData(empty, data);
+    expect(top).to.eql({
+      type: "suite",
+      id: "top",
+      label: "top",
+      children: [
+        {
+          type: "suite",
+          id: "top/Module",
+          label: "Module",
+          children: [
+            {
+              type: "test",
+              id: "top/Module/test",
+              label: "test",
+              data,
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("add to suite", () => {
+    const data: TestCompleted = {
+      tag: "testCompleted",
+      labels: ["Module", "test"],
+      messages: [],
+      duration: 0,
+      status: { tag: "pass" },
+    };
+
+    const top: RunTestSuite = {
+      type: "suite",
+      id: "top",
+      label: "top",
+      children: [
+        {
+          type: "suite",
+          id: "top/Module",
+          label: "Module",
+          children: [
+            {
+              type: "test",
+              id: "top/Module/test",
+              label: "test",
+              data,
+            },
+          ],
+        },
+      ],
+    };
+
+    const data2: TestCompleted = {
+      tag: "testCompleted",
+      labels: ["Module", "test2"],
+      messages: [],
+      duration: 0,
+      status: { tag: "pass" },
+    };
+
+    const top1 = insertRunTestData(top, data2);
+    expect(top1).to.eql({
+      type: "suite",
+      id: "top",
+      label: "top",
+      children: [
+        {
+          type: "suite",
+          id: "top/Module",
+          label: "Module",
+          children: [
+            {
+              type: "test",
+              id: "top/Module/test",
+              label: "test",
+              data,
+            },
+            {
+              type: "test",
+              id: "top/Module/test2",
+              label: "test2",
+              data: data2,
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("duplicate", () => {
+    const data: TestCompleted = {
+      tag: "testCompleted",
+      labels: ["Module", "test"],
+      messages: [],
+      duration: 0,
+      status: { tag: "pass" },
+    };
+
+    const top: RunTestSuite = {
+      type: "suite",
+      id: "top",
+      label: "top",
+      children: [
+        {
+          type: "suite",
+          id: "top/Module",
+          label: "Module",
+          children: [
+            {
+              type: "test",
+              id: "top/Module/test",
+              label: "test",
+              data,
+            },
+          ],
+        },
+      ],
+    };
+    expect(() => insertRunTestData(top, data)).to.throw(
+      "duplicate id 'top/Module/test'",
+    );
+  });
+});

--- a/client/src/test-runner/util.ts
+++ b/client/src/test-runner/util.ts
@@ -22,7 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 import { TestSuiteInfo, TestInfo } from "vscode-test-adapter-api";
-import { EventTestCompleted } from "./result";
+import { TestCompleted } from "./result";
 
 export function* walk(
   node: TestSuiteInfo | TestInfo,
@@ -83,7 +83,7 @@ export function buildElmTestArgsWithReport(args: string[]): string[] {
   return args.concat(["--report", "json"]);
 }
 
-export function getFilePath(event: EventTestCompleted): string {
+export function getFilePath(event: TestCompleted): string {
   const module = event.labels[0];
   const file = module.split(".").join("/");
   return `${file}.elm`;


### PR DESCRIPTION
- only the adapter depends on test-explorer-api
- do not reuse runner instances

This refactoring will simplify the move to VSCode Testing API, if it is to replace Test Explorer UI.