### PR TITLE
Fix extract function code action being triggered too early

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -66,7 +66,6 @@ export interface IRefactorCodeAction extends Omit<CodeAction, "isPreferred"> {
 const clients: Map<string, LanguageClient> = new Map<string, LanguageClient>();
 
 export function activate(context: ExtensionContext): void {
-  let isRegistered = false;
   const module = context.asAbsolutePath(path.join("server", "out", "index.js"));
 
   const config = Workspace.getConfiguration().get<IClientSettings>("elmLS");
@@ -129,14 +128,12 @@ export function activate(context: ExtensionContext): void {
 
         RefactorAction.registerCommands(client, context, workspaceId);
         ExposeUnexposeAction.registerCommands(client, context, workspaceId);
-        if (!isRegistered) {
-          registerDidApplyRefactoringCommand(context);
-          isRegistered = true;
-        }
 
         TestRunner.activate(context, workspaceFolder, client);
       }
     });
+
+    registerDidApplyRefactoringCommand(context);
   });
 
   Workspace.onDidChangeWorkspaceFolders(async (event) => {

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -66,6 +66,7 @@ export interface IRefactorCodeAction extends Omit<CodeAction, "isPreferred"> {
 const clients: Map<string, LanguageClient> = new Map<string, LanguageClient>();
 
 export function activate(context: ExtensionContext): void {
+  let isRegistered = false;
   const module = context.asAbsolutePath(path.join("server", "out", "index.js"));
 
   const config = Workspace.getConfiguration().get<IClientSettings>("elmLS");
@@ -128,7 +129,10 @@ export function activate(context: ExtensionContext): void {
 
         RefactorAction.registerCommands(client, context, workspaceId);
         ExposeUnexposeAction.registerCommands(client, context, workspaceId);
-        registerDidApplyRefactoringCommand(context);
+        if (!isRegistered) {
+          registerDidApplyRefactoringCommand(context);
+          isRegistered = true;
+        }
 
         TestRunner.activate(context, workspaceFolder, client);
       }
@@ -192,7 +196,7 @@ export function deactivate(): Thenable<void> | undefined {
 }
 
 const didApplyRefactoringCommandId = "elm.didApplyRefactoring";
-function registerDidApplyRefactoringCommand(context: ExtensionContext) {
+function registerDidApplyRefactoringCommand(context: ExtensionContext): void {
   context.subscriptions.push(
     commands.registerCommand(
       didApplyRefactoringCommandId,


### PR DESCRIPTION
We were incorrectly running the extract method code action on the resolve request. The resolve request is just to fill in the edits, not to run the request. Instead we need to pass a command that will triggered after the code action is triggered. Most of the time, the code action was resolved when the code action was triggered, so it didn't cause any issues. But recently the Live Share extension changed it to eagerly resolve all code action when they are requested. This caused us to manually trigger the extract function every time a code action was requested, but not triggered.

Fixes #208. 