### PR TITLE
Fix Elm: Browse/Install package commands not working

### DIFF
--- a/client/src/node/elmPackage.ts
+++ b/client/src/node/elmPackage.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 import * as utils from "./utils";
-import request from "request-light";
+import * as request from "request-light";
 
 let packageTerminal: vscode.Terminal;
 


### PR DESCRIPTION
When trying to use the `Elm: Browse/Install Package` action it fails with the following error:

![image](https://github.com/elm-tooling/elm-language-client-vscode/assets/3757388/8c5c4da2-3954-4345-8604-16d3f4e1fb56)

It broke in this commit https://github.com/elm-tooling/elm-language-client-vscode/pull/569/files#diff-a337073cd85a49ed02f679ed8a5b7cedc7a60a5cf8f129368a14719de9519b2d which changed the import syntax, but since `request-light` doesn't have a default export nothing is imported.

The following changes fixes that by importing the `request-light` namespace as request.
