### PR TITLE
Publish verified VSIX artifacts

### DIFF
--- a/.github/workflows/deploy_extension.yaml
+++ b/.github/workflows/deploy_extension.yaml
@@ -17,13 +17,15 @@ jobs:
         with:
           node-version: 24
       - run: npm ci
-      - run: npm run compile -- --minify
+      - run: npm run package
       - name: Publish to Visual Studio Marketplace
         uses: HaaLeo/publish-vscode-extension@v2
         with:
           pat: ${{ secrets.VS_MARKETPLACE_TOKEN }}
+          extensionFile: elm-ls-vscode.vsix
           registryUrl: https://marketplace.visualstudio.com
       - name: Publish to Open VSX Registry
         uses: HaaLeo/publish-vscode-extension@v2
         with:
           pat: ${{ secrets.OPEN_VSX_TOKEN }}
+          extensionFile: elm-ls-vscode.vsix

--- a/.github/workflows/deploy_extension_prerelease.yaml
+++ b/.github/workflows/deploy_extension_prerelease.yaml
@@ -17,10 +17,10 @@ jobs:
         with:
           node-version: 24
       - run: npm ci
-      - run: npm run compile -- --minify
+      - run: npm run package:pre-release
       - name: Publish to Visual Studio Marketplace
         uses: HaaLeo/publish-vscode-extension@v2
         with:
           pat: ${{ secrets.VS_MARKETPLACE_TOKEN }}
-          preRelease: true
+          extensionFile: elm-ls-vscode.vsix
           registryUrl: https://marketplace.visualstudio.com

--- a/package.json
+++ b/package.json
@@ -201,7 +201,8 @@
     "pretest:e2e-web": "npm run compile",
     "test:e2e-web": "node ./scripts/e2e-web.mjs",
     "verify": "npm run compile && npm run smoke && npm --prefix client run lint && npm --prefix client test",
-    "package": "npm run compile -- --minify && npm run smoke && vsce package --no-dependencies --out elm-ls-vscode.vsix && node ./scripts/verify-vsix.mjs elm-ls-vscode.vsix"
+    "package": "npm run compile -- --minify && npm run smoke && vsce package --no-dependencies --out elm-ls-vscode.vsix && node ./scripts/verify-vsix.mjs elm-ls-vscode.vsix",
+    "package:pre-release": "npm run compile -- --minify && npm run smoke && vsce package --pre-release --no-dependencies --out elm-ls-vscode.vsix && node ./scripts/verify-vsix.mjs elm-ls-vscode.vsix"
   },
   "devDependencies": {
     "@types/mocha": "^10.0.6",


### PR DESCRIPTION
## Summary

- package prereleases with the current repository VSCE and the pre-release marker
- publish the verified VSIX instead of repackaging with the action legacy VSCE
- reuse one verified stable VSIX for Marketplace and Open VSX

## Verification

- npm run package:pre-release
- VSIX content verification
- confirmed Microsoft.VisualStudio.Code.PreRelease=true in the manifest

This fixes the failed 2.9.0 prerelease deployment, which looked for out/nodeClient.mjs.js.